### PR TITLE
HW 8.2 done

### DIFF
--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/impl/UsersApiClient.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/service/impl/UsersApiClient.java
@@ -9,11 +9,15 @@ import guru.qa.niffler.model.TestData;
 import guru.qa.niffler.model.rest.UserJson;
 import guru.qa.niffler.service.UsersClient;
 import io.qameta.allure.Step;
+import org.apache.hc.core5.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Response;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import static guru.qa.niffler.utils.RandomDataUtils.randomUsername;
 import static java.util.Objects.requireNonNull;
@@ -131,5 +135,18 @@ public class UsersApiClient implements UsersClient {
                         .add(response.body());
             }
         }
+    }
+
+    @Step("Get all users for user using REST API")
+    public @Nonnull List<UserJson> getAllUsers(String username) {
+        final Response<List<UserJson>> response;
+        try {
+            response = userdataApi.allUsers(username, null)
+                    .execute();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        assertEquals(HttpStatus.SC_SUCCESS, response.code());
+        return response.body() != null ? response.body() : Collections.emptyList();
     }
 }

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/EmptyDbTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/EmptyDbTest.java
@@ -1,0 +1,23 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.model.rest.UserJson;
+import guru.qa.niffler.service.impl.UsersApiClient;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Order(1)
+public class EmptyDbTest {
+
+    private final UsersApiClient usersApiClient = new UsersApiClient();
+
+    @Test
+    void checkEmptyUsersList() {
+        List<UserJson> users = usersApiClient.getAllUsers("filkot");
+        assertTrue(users.isEmpty());
+    }
+
+}

--- a/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/FullDbTest.java
+++ b/niffler-e-2-e-tests/src/test/java/guru/qa/niffler/test/web/FullDbTest.java
@@ -1,0 +1,23 @@
+package guru.qa.niffler.test.web;
+
+import guru.qa.niffler.model.rest.UserJson;
+import guru.qa.niffler.service.impl.UsersApiClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@Isolated
+public class FullDbTest {
+
+    private final UsersApiClient usersApiClient = new UsersApiClient();
+
+
+    @Test
+    void checkNotEmptyUsersList() {
+        List<UserJson> users = usersApiClient.getAllUsers("filkot");
+        assertFalse(users.isEmpty());
+    }
+}


### PR DESCRIPTION
Реализовать 2 простых АРІ теста на internal APl(без походов в gateway):
Для пользователя возвращается пустой / не пустой список из /internal/users/all


• Тест на пустой список должен всегда запускаться первым
• Тест на не пустой - последним
• Остальные тесты должны выполняться параллельно.